### PR TITLE
Update URL for /hup easter egg

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,7 +271,7 @@ var (
 			up := rand.Intn(100)
 			gif := "https://tenor.com/view/kitten-cat-jump-running-cute-gif-21817165"
 			if up < 5 {
-				gif = "https://cdn.discordapp.com/attachments/990457249161961502/991831809501450361/etr5se.gif"
+				gif = "https://cdn.discordapp.com/attachments/401890282309812225/1015239767891390517/etr5se.gif"
 			}
 			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,


### PR DESCRIPTION
According to [this](https://support.discord.com/hc/en-us/community/posts/360061593771-Privacy-for-CDN-attachements#:~:text=When%20you%20send%20an%20attachement,it%20using%20the%20same%20url.) attachments on Discord should be saved forever, but the old URL has gone stale anyway.